### PR TITLE
Add support for SSL certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ server/node_modules
 /.pnp
 .pnp.js
 certs/
-client/
+data/
 
 # testing
 /coverage

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ client/node_modules
 server/node_modules
 /.pnp
 .pnp.js
+certs/
+client/
 
 # testing
 /coverage

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "yzhang.markdown-all-in-one"
+    ]
+}

--- a/.vscode/project.code-workspace
+++ b/.vscode/project.code-workspace
@@ -10,7 +10,8 @@
       "settings": {
         "files.exclude": {
           "dist": true,
-          "node_modules": true
+          "node_modules": true,
+          "data": true
         }
       }
     },

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,5 @@
 <!-- omit in toc -->
+
 # Notes about the code
 
 This project wound up demonstrating techniques for dealing with a ton of different things,
@@ -6,8 +7,14 @@ many of which made me bang my head against my desk for quite a while. Here are n
 those things so future me doesn't go through all that pain again.
 
 <!-- toc -->
-- [Runtime environment variables with ReactJS and Docker images](#runtime-environment-variables-with-reactjs-and-docker-images)
-- [Setting up react-leaflet](#setting-up-react-leaflet)
+
+- [Notes about the code](#notes-about-the-code)
+  - [Runtime environment variables with ReactJS and Docker images](#runtime-environment-variables-with-reactjs-and-docker-images)
+  - [Running a .sh file as a Docker ENTRYPOINT with Docker for Windows](#running-a-sh-file-as-a-docker-entrypoint-with-docker-for-windows)
+  - [Deploying with Docker - SSL configuration](#deploying-with-docker---ssl-configuration)
+    - [The server](#the-server)
+    - [The client](#the-client)
+  - [Setting up react-leaflet](#setting-up-react-leaflet)
 
 ## Runtime environment variables with ReactJS and Docker images
 
@@ -15,17 +22,76 @@ Docker and environment variables go hand-in-hand. Being able to create a single 
 configuration via env vars is a great way to distribute your projects to others. But React?
 React makes it hard because it is webpack'ed and essentially just static files served
 at runtime. Any environment variables you might use via process.ENV are baked in to the
-code as strings *at build time*, which makes them unchangeable with Docker configs.
+code as strings _at build time_, which makes them unchangeable with Docker configs.
 
 The solution is to inject them into a small .js file when the Docker container starts.
 There are several blog posts around that show ways to do this, but for the moment
 I'm using the [example shown here][env-docker-runtime].
 
-While this does work it is *super sensitive* to paths. Make sure the Dockerfile
+While this does work it is _super sensitive_ to paths. Make sure the Dockerfile
 creates the folder where the docker-entrypoint.sh file will live in the final image.
 Make sure the script writes the env_vars.js file to the same folder where the Dockerfile
 put the compiled React app. I lost a lot of time getting this working due to
 mismatched file locations.
+
+## Running a .sh file as a Docker ENTRYPOINT with Docker for Windows
+
+Turns out that it's not as simple as just adding the .sh file to your Docker image
+and referencing it as the `ENTRYPOINT` in your Dockerfile. Why? Because of line endings.
+
+Seriously.
+
+If you get an error starting up the image saying the .sh file can't be found, even though
+it is *clearly* in the image, it's because the line endings are Windows-style (CRLF) and
+simply won't work. They have to be Unix-style (LF).
+
+To fix this in Visual Studio Code open the .sh file and in the bottom right of the
+status bar click on `CRLF` and change it to `LF`. Beware though! Git has a setting
+to auto-set line endings based on the OS you're using. This needs to be disabled for
+whatever your .sh file is in your repo otherwise Git might change it back to CRLF on you!
+
+To disable it use a `.gitattributes` file with a line similar to this:
+
+```
+client/docker-entrypoint.sh text eol=lf
+```
+
+An example is available in the root folder of this repo.
+
+## Deploying with Docker - SSL configuration
+
+Both the client and the server need to be running over HTTPS. Technically they could run
+over HTTP however mobile browsers block geolocation unless the site was served over HTTPS.
+Since the primary use of this site is on mobile setting up SSL was a requirement.
+
+A sample `docker-compose.yml` with all the appropriate configurations for this is
+available in the `deployment` folder.
+
+### The server
+
+The server is easy since I have full control over the setup of ExpressJS and the
+Docker image published to the repository doesn't need any modifications.
+
+The code for starting up the server checks to see if SSL files are present in the `/certs`
+folder and if so uses them to start the http server. This code is in [startServer()](server/src/server.mts).
+The docker-compose.yml file simply has to mount a volume to `/certs` with a `privkey.pem`
+and `fullchain.pem` file.
+
+### The client
+
+This is a bit more complicated. The client is webpacked and runs using nginx. It's
+not enough to map a volume with the certs, the Docker image itself needs to be modified
+to add an nginx config file.
+
+This is done using a deployment Dockerfile that references the published client image
+and simply copies in a `nginx.conf` file to `/etc/nginx/conf.d/nginx.conf`. The path
+and name of this file is important and there are a LOT of random stackoverflow
+and blog posts out there that use the wrong ones. A sample, working, `nginx.conf`
+file is available in the `deployment` folder.
+
+The docker-compose.yml file uses this Dockerfile to start the client image, with
+the certs mounted as a volume to `/etc/nginx/ssl`. As with the server image the
+certificate files should be named `privkey.pem` and `fullchain.pem`.
 
 ## Setting up react-leaflet
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/neilenns/access-code-map-client:latest
 
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/nginx.conf

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       # This must be set to the domain and port of the *client*.
       - WHITELISTED_DOMAINS=http://tom:3000
       - PORT=3001
+    volumes:
+      - ./certs:/certs
     depends_on:
       - mongodb
 
@@ -39,7 +41,7 @@ services:
       - 3000:443
     environment:
       # This must be set to the domain and port of the *server*.
-      - REACT_APP_SERVER_URL=http://tom:3001/
+      - REACT_APP_SERVER_URL=https://tom:3001/
     volumes:
       - ./certs:/etc/nginx/ssl
     depends_on:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -36,11 +36,11 @@ services:
     build:
       context: .
     ports:
-      - 3000:80
+      - 3000:443
     environment:
       # This must be set to the domain and port of the *server*.
       - REACT_APP_SERVER_URL=http://tom:3001/
     volumes:
-      - h:\:/etc/nginx/ssl
+      - ./certs:/etc/nginx/ssl
     depends_on:
       - server

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - MONGO_DB_NAME=access-code-map
       - COOKIE_SECRET=a5b6e1f7-3be7-4d8a-9c9f-2e86d2f1b7bc
       # This must be set to the domain and port of the *client*.
-      - WHITELISTED_DOMAINS=http://tom:3000
+      - WHITELISTED_DOMAINS=https://danecreekphoto.duckdns.org:3000
       - PORT=3001
     volumes:
       - ./certs:/certs
@@ -40,8 +40,11 @@ services:
     ports:
       - 3000:443
     environment:
-      # This must be set to the domain and port of the *server*.
-      - REACT_APP_SERVER_URL=https://tom:3001/
+      # This must be set to the domain and port of the *server*. Note https in front
+      # to ensure it uses SSL when making server calls. Without this there will be
+      # errors in the browser attempting to call the server via HTTP when the
+      # client is HTTPS.
+      - REACT_APP_SERVER_URL=https://danecreekphoto.duckdns.org:3001/
     volumes:
       - ./certs:/etc/nginx/ssl
     depends_on:

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,0 +1,12 @@
+server {
+	listen 443 ssl;
+	server_name danecreekphoto.duckdns.org;
+
+	ssl_certificate /etc/nginx/ssl/fullchain.pem;
+	ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+	location / {
+		root /usr/share/nginx/html;
+		index index.html;
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - WHITELISTED_DOMAINS=http://tom:3000
       - PORT=3001
     volumes:
-      - ./certs:/etc/nginx/ssl
+      - h:\:/etc/nginx/ssl
     depends_on:
       - mongodb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 version: '3.8'
 
+name: access-code-map
+
 services:
   mongodb:
     image: mongo:latest
+    container_name: access-code-mongodb
     restart: always
+    volumes:
+      - ./data:/data/db
     ports:
       - 27017:27017
 
@@ -18,7 +23,7 @@ services:
       - REFRESH_TOKEN_SECRET=f2f8c61e-d08b-4df2-9be9-8507a3d4a8ca
       - SESSION_EXPIRY=900
       - REFRESH_TOKEN_EXPIRY=2592000
-      - MONGO_DB_CONNECTION_STRING=mongodb://mongodb:27017/
+      - MONGO_DB_CONNECTION_STRING=mongodb://access-code-mongodb:27017
       - MONGO_DB_NAME=access-code-map
       - COOKIE_SECRET=a5b6e1f7-3be7-4d8a-9c9f-2e86d2f1b7bc
       # This must be set to the domain and port of the *client*.
@@ -35,6 +40,6 @@ services:
       - 3000:80
     environment:
       # This must be set to the domain and port of the *server*.
-      - REACT_APP_SERVER_URL=http://localhost:3001/
+      - REACT_APP_SERVER_URL=http://tom:3001/
     depends_on:
       - server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       # This must be set to the domain and port of the *client*.
       - WHITELISTED_DOMAINS=http://tom:3000
       - PORT=3001
+    volumes:
+      - ./certs:/etc/nginx/ssl
     depends_on:
       - mongodb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
       # This must be set to the domain and port of the *client*.
       - WHITELISTED_DOMAINS=http://tom:3000
       - PORT=3001
-    volumes:
-      - h:\:/etc/nginx/ssl
     depends_on:
       - mongodb
 
@@ -41,5 +39,7 @@ services:
     environment:
       # This must be set to the domain and port of the *server*.
       - REACT_APP_SERVER_URL=http://tom:3001/
+    volumes:
+      - h:\:/etc/nginx/ssl
     depends_on:
       - server

--- a/server/src/server.mts
+++ b/server/src/server.mts
@@ -11,6 +11,8 @@ import cookieParser from "cookie-parser";
 import userRouter from "./routes/user.mjs";
 import defaultRouter from "./routes/default.mjs";
 import locationsRouter from "./routes/locations.mjs";
+import fs from "fs";
+import https from "https";
 
 // Authentication
 import "./strategies/jwtStrategy.mjs";
@@ -22,9 +24,25 @@ const port = process.env.PORT || 3001;
 async function startServer() {
   await connectToDatabase();
 
-  app.listen(port, () => {
-    console.log(`Server started on port ${port}`);
-  });
+  const certFilesExist =
+    fs.existsSync("/certs/privkey.pem") &&
+    fs.existsSync("/certs/fullchain.pem");
+
+  if (certFilesExist) {
+    const options = {
+      key: fs.readFileSync("/certs/privkey.pem"),
+      cert: fs.readFileSync("/certs/fullchain.pem"),
+    };
+
+    const server = https.createServer(options, app);
+    server.listen(port, () => {
+      console.log(`Server running on port ${port}`);
+    });
+  } else {
+    app.listen(port, () => {
+      console.log(`Server started on port ${port}`);
+    });
+  }
 }
 
 const app = express();


### PR DESCRIPTION
* Add SSL support to the server
* Add SSL support to the client Docker image
* Add sample deployment files to a new `deployment` directory
* Add LOTS of documentation about how stupid this was to the `DEVELOPMENT.MD` file