### PR TITLE
Fix refresh not knowing you are logged in

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,11 +17,6 @@ function App() {
   const [loading, setLoading] = useState(true);
 
   const verifyUser = useCallback(() => {
-    if (!userContext.token) {
-      setLoading(false);
-      return;
-    }
-
     axios
       .post(
         new URL("users/refreshToken", serverUrl).toString(),
@@ -40,7 +35,6 @@ function App() {
         setTimeout(verifyUser, 5 * 60 * 1000);
       })
       .catch((err) => {
-        console.log(`Error: ${err}`);
         setUserContext((oldValues) => {
           return { ...oldValues, token: null };
         });

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -10,7 +10,7 @@ const Login = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [password, setPassword] = useState("");
-  const [userContext, setUserContext] = useContext(UserContext);
+  const [, setUserContext] = useContext(UserContext);
 
   const formSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -35,7 +35,6 @@ const Login = () => {
         setUserContext((oldValues: any) => {
           return { ...oldValues, token: response.data.token };
         });
-        console.log(userContext);
       })
       .catch((error) => {
         if (error.response.status === 400) {


### PR DESCRIPTION
Fixes #58

Revert the code I added previously that completely broke things. verifyRefresh *has* to call with a null token when you refresh the page. That's how it works to get the updated token.