### PR TITLE
Use email for username and clean up form types

### DIFF
--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -6,7 +6,7 @@ import { serverUrl } from "../configs/accessCodeServer";
 import axios from "axios";
 
 const Login = () => {
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [password, setPassword] = useState("");
@@ -23,7 +23,7 @@ const Login = () => {
       .post(
         new URL("users/login", serverUrl).toString(),
         {
-          username,
+          username: email,
           password,
         },
         {
@@ -54,19 +54,22 @@ const Login = () => {
     <>
       <form className="auth-form" onSubmit={formSubmitHandler}>
         <TextField
-          label="Username"
+          label="Email"
+          required={true}
           variant="outlined"
+          type="email"
           margin="normal"
           fullWidth
-          value={username}
+          value={email}
           error={error !== ""}
           helperText={error}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setUsername(e.target.value)
+            setEmail(e.target.value)
           }
         />
         <TextField
           label="Password"
+          required={true}
           variant="outlined"
           margin="normal"
           fullWidth

--- a/client/src/components/Register.tsx
+++ b/client/src/components/Register.tsx
@@ -9,7 +9,7 @@ const Register = () => {
   const [error, setError] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [registerSuccess, setRegisterSuccess] = useState(false);
 
@@ -26,7 +26,7 @@ const Register = () => {
         {
           firstName,
           lastName,
-          username,
+          username: email,
           password,
         },
         {
@@ -60,6 +60,7 @@ const Register = () => {
           <TextField
             label="First Name"
             variant="outlined"
+            required={true}
             margin="normal"
             fullWidth
             value={firstName}
@@ -70,6 +71,7 @@ const Register = () => {
           <TextField
             label="Last Name"
             variant="outlined"
+            required={true}
             margin="normal"
             fullWidth
             value={lastName}
@@ -78,18 +80,21 @@ const Register = () => {
             }
           />
           <TextField
-            label="Username"
+            label="Email"
             variant="outlined"
+            required={true}
+            type="email"
             margin="normal"
             fullWidth
-            value={username}
+            value={email}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setUsername(e.target.value)
+              setEmail(e.target.value)
             }
           />
           <TextField
             label="Password"
             variant="outlined"
+            required={true}
             margin="normal"
             fullWidth
             type="password"


### PR DESCRIPTION
Fixes #33

Using email instead of username means the username field can be set to an email input type and get all sorts of auto-validation and auto-complete nonsense. Also set up the other properties such as required on the fields, more auto-validation goodness.