### PR TITLE
UI cleanup for edit dialog

### DIFF
--- a/client/src/components/LocationMarkers.tsx
+++ b/client/src/components/LocationMarkers.tsx
@@ -21,6 +21,7 @@ export interface ILocationMarkerProps {}
 export default function LocationMarkers(props: ILocationMarkerProps) {
   const [locations, setLocations] = React.useState<ILocation[]>([]);
   const [isEditOpen, setIsEditOpen] = React.useState<boolean>(false);
+  const [isEdit, setIsEdit] = React.useState<boolean>(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] =
     React.useState<boolean>(false);
   const [selectedLocation, setSelectedLocation] = React.useState<ILocation>({});
@@ -78,6 +79,7 @@ export default function LocationMarkers(props: ILocationMarkerProps) {
 
     if (location) {
       setSelectedLocation(location);
+      setIsEdit(true);
       setIsEditOpen(true);
     }
   }
@@ -176,6 +178,7 @@ export default function LocationMarkers(props: ILocationMarkerProps) {
     };
 
     setSelectedLocation(newLocation);
+    setIsEdit(false);
     setIsEditOpen(true);
   });
 
@@ -202,6 +205,7 @@ export default function LocationMarkers(props: ILocationMarkerProps) {
       ))}
       <MarkerEditDialog
         isOpen={isEditOpen}
+        isEdit={isEdit}
         location={selectedLocation}
         onSave={onMarkerEditSave}
         onCancel={onMarkerEditCancel}

--- a/client/src/components/MarkerEditDialog.tsx
+++ b/client/src/components/MarkerEditDialog.tsx
@@ -12,20 +12,33 @@ import {
   Dialog,
   Button,
 } from "@mui/material";
+import styled from "@mui/system/styled";
 
 interface IMarkerEditDialogProps {
   isOpen: boolean;
   location: ILocation;
+  isEdit: boolean;
   onSave: (location: ILocation) => void;
   onCancel: () => void;
 }
 
+// This method of making a top-aligned styled MUI dialog comes from
+// https://stackoverflow.com/a/73745188/9206264. Any other method that
+// mention using makeStyles doesn't work with MUI v5 and React 18 or later.
+const TopAlignedDialog = styled(Dialog)(({ theme }) => ({
+  "& .MuiDialog-container": {
+    alignItems: "flex-start",
+  },
+}));
+
 export const MarkerEditDialog: React.FC<IMarkerEditDialogProps> = (props) => {
   const [location, setLocation] = useState<ILocation>({});
+  const [isEdit, setIsEdit] = useState<boolean>(false);
 
   useEffect(() => {
     setLocation(props.location);
-  }, [props.location]);
+    setIsEdit(props.isEdit);
+  }, [props.location, props.isEdit]);
 
   const onDialogSave: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     props.onSave(location);
@@ -36,18 +49,26 @@ export const MarkerEditDialog: React.FC<IMarkerEditDialogProps> = (props) => {
   };
 
   return (
-    <Dialog open={props.isOpen} onClose={onDialogClose}>
-      <DialogTitle>Add access code</DialogTitle>
+    // disableRestoreFocus is required due to a bug in MUI that prevents autoFocus
+    // on the text field from working when React strict mode is enabled. See
+    // https://github.com/mui/material-ui/issues/33004#issuecomment-1455260156
+    <TopAlignedDialog
+      open={props.isOpen}
+      onClose={onDialogClose}
+      disableRestoreFocus
+      aria-labelledby="marker-edit-dialog-title"
+    >
+      <DialogTitle id="marker-edit-dialog-title">
+        {isEdit ? "Edit" : "Add"} access code
+      </DialogTitle>
       <DialogContent>
         <TextField
-          autoFocus
           defaultValue={props.location.title}
           margin="dense"
           id="title"
           label="Title"
           type="text"
           fullWidth
-          variant="standard"
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setLocation({ ...location, title: e.target.value });
           }}
@@ -60,9 +81,8 @@ export const MarkerEditDialog: React.FC<IMarkerEditDialogProps> = (props) => {
           label="Note"
           type="text"
           multiline
-          rows={4}
+          rows={3}
           fullWidth
-          variant="standard"
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setLocation({ ...location, note: e.target.value });
           }}
@@ -72,6 +92,6 @@ export const MarkerEditDialog: React.FC<IMarkerEditDialogProps> = (props) => {
         <Button onClick={onDialogClose}>Cancel</Button>
         <Button onClick={onDialogSave}>Save</Button>
       </DialogActions>
-    </Dialog>
+    </TopAlignedDialog>
   );
 };


### PR DESCRIPTION
Fixes #64 

* Align the dialog to the top of the page
* Clean up the style of the edit fields to match the login page
* Auto focus on the notes field
* Shrink the multi-line field to three lines
* Make the dialog title reflect the actual action (add vs. edit)