### PR TITLE
If a building name is returned from reverse geolocate use it and not the address

### DIFF
--- a/client/src/components/LocationMarkers.tsx
+++ b/client/src/components/LocationMarkers.tsx
@@ -168,9 +168,13 @@ export default function LocationMarkers(props: ILocationMarkerProps) {
 
     const newLocation = {
       title: geoDetails
-        ? `${geoDetails.address?.building ?? ""} ${
-            geoDetails.address?.house_number ?? ""
-          } ${geoDetails.address?.road ?? ""}`.trim()
+        ? `${
+            geoDetails.address?.building
+              ? geoDetails.address.building
+              : `${geoDetails.address?.house_number ?? ""} ${
+                  geoDetails.address?.road ?? ""
+                }`.trim()
+          }`
         : "",
       latitude: e.latlng.lat,
       longitude: e.latlng.lng,


### PR DESCRIPTION
Fixes #67 