### PR TITLE
Put the blue dot back after an address lookup

### DIFF
--- a/client/src/components/GeocodeControl.tsx
+++ b/client/src/components/GeocodeControl.tsx
@@ -18,7 +18,7 @@ function createGeocodeInstance(props: P) {
       },
     }),
     style: "bar",
-    showMarker: false,
+    showMarker: true,
     autoClose: true,
     keepResult: true,
     ...props,


### PR DESCRIPTION
Fixes #94

Sadly it's the standard pin marker :( Not a blue dot. Will have to do for now.